### PR TITLE
Feature/verify all back ups in date range

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
@@ -137,8 +137,7 @@ public class BackupVerification {
                 backupVerificationResult.remotePath =
                         snapshotLocation.subpath(1, snapshotLocation.getNameCount()).toString();
                 result.add(backupVerificationResult);
-            }
-            else {
+            } else {
                 BackupVerificationResult backupVerificationResult =
                         verifyBackup(metaProxy, backupMetadata);
                 if (logger.isDebugEnabled())

--- a/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
@@ -108,6 +108,54 @@ public class BackupVerification {
         return Optional.empty();
     }
 
+    public List<BackupVerificationResult> verifyAllBackups(
+            BackupVersion backupVersion, boolean force, DateRange dateRange)
+            throws UnsupportedTypeException, IllegalArgumentException {
+        IMetaProxy metaProxy = getMetaProxy(backupVersion);
+        if (metaProxy == null) {
+            throw new UnsupportedTypeException(
+                    "BackupVersion type: " + backupVersion + " is not supported");
+        }
+
+        if (dateRange == null) {
+            throw new IllegalArgumentException("dateRange provided is null");
+        }
+
+        List<BackupVerificationResult> result = new ArrayList<>();
+
+        List<BackupMetadata> metadata =
+                backupStatusMgr.getLatestBackupMetadata(backupVersion, dateRange);
+        if (metadata == null || metadata.isEmpty()) return result;
+        for (BackupMetadata backupMetadata : metadata) {
+            if (backupMetadata.getLastValidated() != null && !force) {
+                // Backup is already validated. Nothing to do.
+                BackupVerificationResult backupVerificationResult = new BackupVerificationResult();
+                backupVerificationResult.valid = true;
+                backupVerificationResult.manifestAvailable = true;
+                backupVerificationResult.snapshotInstant = backupMetadata.getStart().toInstant();
+                Path snapshotLocation = Paths.get(backupMetadata.getSnapshotLocation());
+                backupVerificationResult.remotePath =
+                        snapshotLocation.subpath(1, snapshotLocation.getNameCount()).toString();
+                result.add(backupVerificationResult);
+            }
+            else {
+                BackupVerificationResult backupVerificationResult =
+                        verifyBackup(metaProxy, backupMetadata);
+                if (logger.isDebugEnabled())
+                    logger.debug(
+                            "BackupVerification: metadata: {}, result: {}",
+                            backupMetadata,
+                            backupVerificationResult);
+                if (backupVerificationResult.valid) {
+                    backupMetadata.setLastValidated(new Date(DateUtil.getInstant().toEpochMilli()));
+                    backupStatusMgr.update(backupMetadata);
+                    result.add(backupVerificationResult);
+                }
+            }
+        }
+        return result;
+    }
+
     private BackupVerificationResult verifyBackup(
             IMetaProxy metaProxy, BackupMetadata latestBackupMetaData) {
         Path metadataLocation = Paths.get(latestBackupMetaData.getSnapshotLocation());

--- a/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
@@ -127,17 +127,7 @@ public class BackupVerification {
                 backupStatusMgr.getLatestBackupMetadata(backupVersion, dateRange);
         if (metadata == null || metadata.isEmpty()) return result;
         for (BackupMetadata backupMetadata : metadata) {
-            if (backupMetadata.getLastValidated() != null && !force) {
-                // Backup is already validated. Nothing to do.
-                BackupVerificationResult backupVerificationResult = new BackupVerificationResult();
-                backupVerificationResult.valid = true;
-                backupVerificationResult.manifestAvailable = true;
-                backupVerificationResult.snapshotInstant = backupMetadata.getStart().toInstant();
-                Path snapshotLocation = Paths.get(backupMetadata.getSnapshotLocation());
-                backupVerificationResult.remotePath =
-                        snapshotLocation.subpath(1, snapshotLocation.getNameCount()).toString();
-                result.add(backupVerificationResult);
-            } else {
+            if (backupMetadata.getLastValidated() == null) {
                 BackupVerificationResult backupVerificationResult =
                         verifyBackup(metaProxy, backupMetadata);
                 if (logger.isDebugEnabled())

--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
@@ -32,9 +32,7 @@ import com.netflix.priam.utils.DateUtil;
 import com.netflix.priam.utils.DateUtil.DateRange;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +93,11 @@ public class BackupVerificationTask extends Task {
                 backupVerification.verifyAllBackups(
                         BackupVersion.SNAPSHOT_META_SERVICE, false, dateRange);
         if (verificationResults.isEmpty()
-                || verificationResults.stream().filter(r -> r.valid).collect(Collectors.toList()).isEmpty()) {
+                || verificationResults
+                        .stream()
+                        .filter(r -> r.valid)
+                        .collect(Collectors.toList())
+                        .isEmpty()) {
             logger.error(
                     "Not able to find any snapshot which is valid in our SLO window: {} hours",
                     backupRestoreConfig.getBackupVerificationSLOInHours());
@@ -103,14 +105,16 @@ public class BackupVerificationTask extends Task {
         } else {
             // verification result is available and is valid.
             // send notification that backup is uploaded.
-            verificationResults.stream().forEach(r -> {
-                logger.info(
-                        "Sending {} message for backup: {}",
-                        AbstractBackupPath.BackupFileType.SNAPSHOT_VERIFIED,
-                        r.snapshotInstant);
-                backupNotificationMgr.notify(r);
-            });
-
+            verificationResults
+                    .stream()
+                    .forEach(
+                            r -> {
+                                logger.info(
+                                        "Sending {} message for backup: {}",
+                                        AbstractBackupPath.BackupFileType.SNAPSHOT_VERIFIED,
+                                        r.snapshotInstant);
+                                backupNotificationMgr.notify(r);
+                            });
         }
     }
 

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
@@ -31,7 +31,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -120,10 +119,11 @@ public class TestBackupVerification {
 
     private void setUp() throws Exception {
         Instant start = DateUtil.parseInstant(backupDate);
-        for(int i=0; i<numFakeBackups-1; i++){
+        for (int i = 0; i < numFakeBackups - 1; i++) {
             backupStatusMgr.finish(
-                    getBackupMetaData(BackupVersion.SNAPSHOT_BACKUP,
-                            start.plus(i+1, ChronoUnit.MINUTES),
+                    getBackupMetaData(
+                            BackupVersion.SNAPSHOT_BACKUP,
+                            start.plus(i + 1, ChronoUnit.MINUTES),
                             Status.FINISHED));
         }
         backupStatusMgr.finish(
@@ -133,10 +133,11 @@ public class TestBackupVerification {
                         BackupVersion.SNAPSHOT_BACKUP,
                         start.plus(20, ChronoUnit.MINUTES),
                         Status.FAILED));
-        for(int i=0; i<numFakeBackups-1; i++){
+        for (int i = 0; i < numFakeBackups - 1; i++) {
             backupStatusMgr.finish(
-                    getBackupMetaData(BackupVersion.SNAPSHOT_META_SERVICE,
-                            start.plus(i+1, ChronoUnit.MINUTES),
+                    getBackupMetaData(
+                            BackupVersion.SNAPSHOT_META_SERVICE,
+                            start.plus(i + 1, ChronoUnit.MINUTES),
                             Status.FINISHED));
         }
         backupStatusMgr.finish(
@@ -186,22 +187,21 @@ public class TestBackupVerification {
                         new DateRange(backupDate + "," + backupDateEnd));
         Assert.assertTrue(!backupVerificationResults.isEmpty());
         Assert.assertTrue(backupVerificationResults.size() == numFakeBackups);
-        backupVerificationResults.stream()
+        backupVerificationResults
+                .stream()
                 .forEach(b -> Assert.assertEquals(Instant.EPOCH, b.snapshotInstant));
         List<BackupMetadata> backupMetadata =
-                backupStatusMgr
-                        .getLatestBackupMetadata(
-                                BackupVersion.SNAPSHOT_BACKUP,
-                                new DateRange(backupDate + "," + backupDateEnd));
+                backupStatusMgr.getLatestBackupMetadata(
+                        BackupVersion.SNAPSHOT_BACKUP,
+                        new DateRange(backupDate + "," + backupDateEnd));
         Assert.assertTrue(!backupMetadata.isEmpty());
         Assert.assertTrue(backupMetadata.size() == numFakeBackups);
         backupMetadata.stream().forEach(b -> Assert.assertNotNull(b.getLastValidated()));
 
         backupMetadata =
-                backupStatusMgr
-                        .getLatestBackupMetadata(
-                                BackupVersion.SNAPSHOT_META_SERVICE,
-                                new DateRange(backupDate + "," + backupDateEnd));
+                backupStatusMgr.getLatestBackupMetadata(
+                        BackupVersion.SNAPSHOT_META_SERVICE,
+                        new DateRange(backupDate + "," + backupDateEnd));
         Assert.assertTrue(!backupMetadata.isEmpty());
         Assert.assertTrue(backupMetadata.size() == numFakeBackups);
         backupMetadata.stream().forEach(b -> Assert.assertNull(b.getLastValidated()));
@@ -267,22 +267,21 @@ public class TestBackupVerification {
                         new DateRange(backupDate + "," + backupDateEnd));
         Assert.assertTrue(!backupVerificationResults.isEmpty());
         Assert.assertTrue(backupVerificationResults.size() == numFakeBackups);
-        backupVerificationResults.stream()
+        backupVerificationResults
+                .stream()
                 .forEach(b -> Assert.assertEquals(Instant.EPOCH, b.snapshotInstant));
         List<BackupMetadata> backupMetadata =
-                backupStatusMgr
-                        .getLatestBackupMetadata(
-                                BackupVersion.SNAPSHOT_META_SERVICE,
-                                new DateRange(backupDate + "," + backupDateEnd));
+                backupStatusMgr.getLatestBackupMetadata(
+                        BackupVersion.SNAPSHOT_META_SERVICE,
+                        new DateRange(backupDate + "," + backupDateEnd));
         Assert.assertTrue(!backupMetadata.isEmpty());
         Assert.assertTrue(backupMetadata.size() == numFakeBackups);
         backupMetadata.stream().forEach(b -> Assert.assertNotNull(b.getLastValidated()));
 
         backupMetadata =
-                backupStatusMgr
-                        .getLatestBackupMetadata(
-                                BackupVersion.SNAPSHOT_BACKUP,
-                                new DateRange(backupDate + "," + backupDateEnd));
+                backupStatusMgr.getLatestBackupMetadata(
+                        BackupVersion.SNAPSHOT_BACKUP,
+                        new DateRange(backupDate + "," + backupDateEnd));
         Assert.assertTrue(!backupMetadata.isEmpty());
         Assert.assertTrue(backupMetadata.size() == numFakeBackups);
         backupMetadata.stream().forEach(b -> Assert.assertNull(b.getLastValidated()));

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
@@ -31,7 +31,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import mockit.Mock;
 import mockit.MockUp;
@@ -48,6 +50,7 @@ public class TestBackupVerification {
     private final IConfiguration configuration;
     private final IBackupStatusMgr backupStatusMgr;
     private final String backupDate = "201812011000";
+    private final String backupDateEnd = "201812021000";
     private final Path location =
             Paths.get(
                     "some_bucket/casstestbackup/1049_fake-app/1808575600",
@@ -56,6 +59,7 @@ public class TestBackupVerification {
                     "SNAPPY",
                     "PLAINTEXT",
                     "meta_v2_201812011000.json");
+    private final int numFakeBackups = 10;
 
     public TestBackupVerification() {
         Injector injector = Guice.createInjector(new BRTestModule());
@@ -116,6 +120,12 @@ public class TestBackupVerification {
 
     private void setUp() throws Exception {
         Instant start = DateUtil.parseInstant(backupDate);
+        for(int i=0; i<numFakeBackups-1; i++){
+            backupStatusMgr.finish(
+                    getBackupMetaData(BackupVersion.SNAPSHOT_BACKUP,
+                            start.plus(i+1, ChronoUnit.MINUTES),
+                            Status.FINISHED));
+        }
         backupStatusMgr.finish(
                 getBackupMetaData(BackupVersion.SNAPSHOT_BACKUP, start, Status.FINISHED));
         backupStatusMgr.failed(
@@ -123,6 +133,12 @@ public class TestBackupVerification {
                         BackupVersion.SNAPSHOT_BACKUP,
                         start.plus(20, ChronoUnit.MINUTES),
                         Status.FAILED));
+        for(int i=0; i<numFakeBackups-1; i++){
+            backupStatusMgr.finish(
+                    getBackupMetaData(BackupVersion.SNAPSHOT_META_SERVICE,
+                            start.plus(i+1, ChronoUnit.MINUTES),
+                            Status.FINISHED));
+        }
         backupStatusMgr.finish(
                 getBackupMetaData(BackupVersion.SNAPSHOT_META_SERVICE, start, Status.FINISHED));
     }
@@ -157,6 +173,38 @@ public class TestBackupVerification {
                         .findFirst();
         Assert.assertTrue(backupMetadata.isPresent());
         Assert.assertNull(backupMetadata.get().getLastValidated());
+    }
+
+    @Test
+    public void verifyBackupVersion1List() throws Exception {
+        setUp();
+        // Verify for backup version 1.0
+        List<BackupVerificationResult> backupVerificationResults =
+                backupVerification.verifyAllBackups(
+                        BackupVersion.SNAPSHOT_BACKUP,
+                        false,
+                        new DateRange(backupDate + "," + backupDateEnd));
+        Assert.assertTrue(!backupVerificationResults.isEmpty());
+        Assert.assertTrue(backupVerificationResults.size() == numFakeBackups);
+        backupVerificationResults.stream()
+                .forEach(b -> Assert.assertEquals(Instant.EPOCH, b.snapshotInstant));
+        List<BackupMetadata> backupMetadata =
+                backupStatusMgr
+                        .getLatestBackupMetadata(
+                                BackupVersion.SNAPSHOT_BACKUP,
+                                new DateRange(backupDate + "," + backupDateEnd));
+        Assert.assertTrue(!backupMetadata.isEmpty());
+        Assert.assertTrue(backupMetadata.size() == numFakeBackups);
+        backupMetadata.stream().forEach(b -> Assert.assertNotNull(b.getLastValidated()));
+
+        backupMetadata =
+                backupStatusMgr
+                        .getLatestBackupMetadata(
+                                BackupVersion.SNAPSHOT_META_SERVICE,
+                                new DateRange(backupDate + "," + backupDateEnd));
+        Assert.assertTrue(!backupMetadata.isEmpty());
+        Assert.assertTrue(backupMetadata.size() == numFakeBackups);
+        backupMetadata.stream().forEach(b -> Assert.assertNull(b.getLastValidated()));
     }
 
     @Test
@@ -206,6 +254,38 @@ public class TestBackupVerification {
                         .findFirst();
         Assert.assertTrue(backupMetadata.isPresent());
         Assert.assertNull(backupMetadata.get().getLastValidated());
+    }
+
+    @Test
+    public void verifyBackupVersion2List() throws Exception {
+        setUp();
+        // Verify for backup version 2.0
+        List<BackupVerificationResult> backupVerificationResults =
+                backupVerification.verifyAllBackups(
+                        BackupVersion.SNAPSHOT_META_SERVICE,
+                        false,
+                        new DateRange(backupDate + "," + backupDateEnd));
+        Assert.assertTrue(!backupVerificationResults.isEmpty());
+        Assert.assertTrue(backupVerificationResults.size() == numFakeBackups);
+        backupVerificationResults.stream()
+                .forEach(b -> Assert.assertEquals(Instant.EPOCH, b.snapshotInstant));
+        List<BackupMetadata> backupMetadata =
+                backupStatusMgr
+                        .getLatestBackupMetadata(
+                                BackupVersion.SNAPSHOT_META_SERVICE,
+                                new DateRange(backupDate + "," + backupDateEnd));
+        Assert.assertTrue(!backupMetadata.isEmpty());
+        Assert.assertTrue(backupMetadata.size() == numFakeBackups);
+        backupMetadata.stream().forEach(b -> Assert.assertNotNull(b.getLastValidated()));
+
+        backupMetadata =
+                backupStatusMgr
+                        .getLatestBackupMetadata(
+                                BackupVersion.SNAPSHOT_BACKUP,
+                                new DateRange(backupDate + "," + backupDateEnd));
+        Assert.assertTrue(!backupMetadata.isEmpty());
+        Assert.assertTrue(backupMetadata.size() == numFakeBackups);
+        backupMetadata.stream().forEach(b -> Assert.assertNull(b.getLastValidated()));
     }
 
     private BackupMetadata getBackupMetaData(

--- a/priam/src/test/java/com/netflix/priam/backupv2/TestBackupVerificationTask.java
+++ b/priam/src/test/java/com/netflix/priam/backupv2/TestBackupVerificationTask.java
@@ -28,7 +28,8 @@ import com.netflix.priam.config.IConfiguration;
 import com.netflix.priam.health.InstanceState;
 import com.netflix.priam.scheduler.UnsupportedTypeException;
 import com.netflix.priam.utils.DateUtil.DateRange;
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.List;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -57,16 +58,17 @@ public class TestBackupVerificationTask {
         public static boolean throwError = false;
 
         @Mock
-        public Optional<BackupVerificationResult> verifyBackup(
+        public List<BackupVerificationResult> verifyAllBackups(
                 BackupVersion backupVersion, boolean force, DateRange dateRange)
                 throws UnsupportedTypeException, IllegalArgumentException {
             if (throwError) throw new IllegalArgumentException("DummyError");
 
-            if (failCall) return Optional.of(new BackupVerificationResult());
+            if (failCall) return new ArrayList<>();
 
-            BackupVerificationResult result = new BackupVerificationResult();
-            result.valid = true;
-            return Optional.of(result);
+            BackupVerificationResult backupVerificationResult = new BackupVerificationResult();
+            backupVerificationResult.valid = true;
+            List<BackupVerificationResult> result = new ArrayList<>();
+            return result;
         }
     }
 


### PR DESCRIPTION
Addressing the last review comment - with this change we will only attempt to send notifications after verifying previously unverified backups for the desired date range.