### PR TITLE
CASS-1731 Addressing the review comments, we now have separated the s…

### DIFF
--- a/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
+++ b/priam/src/main/java/com/netflix/priam/backup/BackupVerification.java
@@ -53,7 +53,7 @@ public class BackupVerification {
         this.abstractBackupPathProvider = abstractBackupPathProvider;
     }
 
-    private IMetaProxy getMetaProxy(BackupVersion backupVersion) {
+    public IMetaProxy getMetaProxy(BackupVersion backupVersion) {
         switch (backupVersion) {
             case SNAPSHOT_BACKUP:
                 return metaV1Proxy;

--- a/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
+++ b/priam/src/main/java/com/netflix/priam/backupv2/BackupVerificationTask.java
@@ -90,19 +90,31 @@ public class BackupVerificationTask extends Task {
                         DateUtil.getInstant());
         List<BackupVerificationResult> verificationResults =
                 backupVerification.verifyAllBackups(BackupVersion.SNAPSHOT_META_SERVICE, dateRange);
-        if (!verificationResults.isEmpty()
-                && verificationResults
-                                .stream()
-                                .filter(backupVerificationResult -> backupVerificationResult.valid)
-                                .count()
-                        == 0) {
+        // There are no backups in our SLO window and hence verification results is empty
+        boolean backupVerificationFailed =
+                (verificationResults.isEmpty()
+                        && !BackupRestoreUtil.getLatestValidMetaPath(
+                                        backupVerification.getMetaProxy(
+                                                BackupVersion.SNAPSHOT_META_SERVICE),
+                                        dateRange)
+                                .isPresent());
+        // There are no valid backups in our SLO window
+        backupVerificationFailed |=
+                !verificationResults.isEmpty()
+                        && verificationResults
+                                        .stream()
+                                        .filter(
+                                                backupVerificationResult ->
+                                                        backupVerificationResult.valid)
+                                        .count()
+                                == 0;
+        if (backupVerificationFailed) {
             logger.error(
                     "Not able to find any snapshot which is valid in our SLO window: {} hours",
                     backupRestoreConfig.getBackupVerificationSLOInHours());
             backupMetrics.incrementBackupVerificationFailure();
         } else {
-            // we would be here if there are no backup verification results
-            // or backup verification results are available and are all valid.
+            // we would be here only if there are valid backup verification results
             // send notifications for each backup that was uploaded and verified.
             verificationResults
                     .stream()

--- a/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
+++ b/priam/src/test/java/com/netflix/priam/backup/TestBackupVerification.java
@@ -20,6 +20,7 @@ package com.netflix.priam.backup;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.priam.backup.AbstractBackupPath.BackupFileType;
+import com.netflix.priam.backupv2.IMetaProxy;
 import com.netflix.priam.backupv2.MetaV1Proxy;
 import com.netflix.priam.backupv2.MetaV2Proxy;
 import com.netflix.priam.config.IConfiguration;
@@ -328,5 +329,11 @@ public class TestBackupVerification {
         result.filesMatched = 123;
         result.snapshotInstant = Instant.EPOCH;
         return result;
+    }
+
+    @Test
+    public void testGetMetaProxy() {
+        IMetaProxy metaProxy = backupVerification.getMetaProxy(BackupVersion.SNAPSHOT_META_SERVICE);
+        Assert.assertTrue(metaProxy != null);
     }
 }


### PR DESCRIPTION
…cenarios where we would get empty backup verification results into 2 checks, 1) Due to all verified backups in our SLO date range, 2) Due to no backups in our SLO date range. We will continue to page for 2, but not for 1.